### PR TITLE
Words with duplicate letters coloured incorrectly

### DIFF
--- a/app.js
+++ b/app.js
@@ -170,7 +170,7 @@ const flipTile = () => {
     })
 
     guess.forEach(guess => {
-        if (checkWordle.includes(guess.letter)) {
+        if (checkWordle.includes(guess.letter) && guess.color != 'green-overlay') {
             guess.color = 'yellow-overlay'
             checkWordle = checkWordle.replace(guess.letter, '')
         }


### PR DESCRIPTION
If the solution has duplicate letters in it then an attempt can be coloured incorrectly.
For example if the solution is AWARD and an attempt is ADORE the 'A' will be coloured yellow as `checkWordle` still contains an 'A'.